### PR TITLE
Expose module to comsumers

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    const lib_mod = b.createModule(.{
+    const lib_mod = b.addModule("stray", .{
         .root_source_file = b.path("root.zig"),
         .target = target,
         .optimize = optimize,


### PR DESCRIPTION
<!--- Thank you for contributing to STRAY! -->

## Description

Without exposing the module, I cannot use it in my Zig project.

## Motivation

`b.createModule` adds a "hidden" module that only your build.zig can access. By changing this to `b.addModule` consumers can now use it in their projects.

## Testing

Cloned it locally, pointed my project at the file system and built.
## Checklist:

<!--- Go over all the following points and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
