### PR TITLE
fix: `icon` destroys the menu

### DIFF
--- a/root.zig
+++ b/root.zig
@@ -112,6 +112,7 @@ pub const TrayIcon = struct {
     }
 
     /// Sets the menu for this tray icon.
+    /// The icon takes ownership, so the menu will be destroyed with the icon.
     pub fn setMenu(self: *TrayIcon, menu: *TrayMenu) void {
         self.menu = menu;
         c.stray_set_menu(self.handle, menu.handle);
@@ -139,15 +140,19 @@ pub const TrayIcon = struct {
     }
 
     /// Destroys the tray icon.
+    /// This will also destroy the menu.
     pub fn destroy(self: *TrayIcon) void {
         if (self.click_context) |ctx| {
             self.allocator.destroy(ctx);
             self.click_context = null;
         }
 
-        // destroy the menu if we own it
+        // clean up the menu contexts
         if (self.menu) |menu| {
-            menu.destroy();
+            for (menu.contexts.items) |ctx| {
+                self.allocator.destroy(ctx);
+            }
+            menu.contexts.deinit();
             self.menu = null;
         }
 
@@ -244,19 +249,6 @@ pub const TrayMenu = struct {
         const label_z = try self.allocator.dupeZ(u8, label);
         defer self.allocator.free(label_z);
         c.stray_menu_set_item_label(self.handle, item_id, label_z.ptr);
-    }
-
-    fn destroy(self: *TrayMenu) void {
-        for (self.contexts.items) |ctx| {
-            self.allocator.destroy(ctx);
-        }
-
-        self.contexts.deinit();
-
-        if (self.handle) |h| {
-            c.stray_menu_destroy(h);
-            self.handle = null;
-        }
     }
 };
 

--- a/stray.h
+++ b/stray.h
@@ -55,7 +55,6 @@ int stray_register(TrayIcon *icon);
 
 /* Menu API */
 TrayMenu *stray_menu_create(void);
-void stray_menu_destroy(TrayMenu *menu);
 void stray_set_menu(TrayIcon *icon, TrayMenu *menu);
 void stray_menu_set_item_label(TrayMenu *menu, int item_id, const char *label);
 int stray_menu_add_separator(TrayMenu *menu);
@@ -1101,11 +1100,7 @@ void stray_menu_set_item_label(TrayMenu *menu, int item_id, const char *label) {
 void stray_set_menu(TrayIcon *icon, TrayMenu *menu) {
     if (!icon) return;
 
-    /* clear back-reference from old menu */
-    if (icon->menu && icon->menu != menu) {
-        icon->menu->icon = NULL;
-        stray_menu_destroy(icon->menu);
-    }
+    if (icon->menu && icon->menu != menu) { icon->menu->icon = NULL; }
 
     icon->menu = menu;
 
@@ -1114,7 +1109,7 @@ void stray_set_menu(TrayIcon *icon, TrayMenu *menu) {
     emit_properties_changed(icon, "All");
 }
 
-void stray_menu_destroy(TrayMenu *menu) {
+static void stray_menu_destroy(TrayMenu *menu) {
     if (!menu) return;
 
     for (int i = 0; i < menu->item_count; i++) {
@@ -1131,7 +1126,14 @@ void stray_menu_destroy(TrayMenu *menu) {
 void stray_destroy(TrayIcon *icon) {
     if (!icon) return;
 
-    /* unregister from D-Bus first */
+    /* destroy menu first */
+    if (icon->menu) {
+        icon->menu->icon = NULL;
+        stray_menu_destroy(icon->menu);
+        icon->menu = NULL;
+    }
+
+    /* unregister from D-Bus */
     if (icon->conn) {
         dbus_connection_unregister_object_path(icon->conn, STRAY_OBJECT_PATH);
         dbus_connection_unregister_object_path(
@@ -1142,7 +1144,6 @@ void stray_destroy(TrayIcon *icon) {
     safe_free(&icon->service_name);
     safe_free(&icon->icon_name);
     safe_free(&icon->title);
-    free(icon->menu);
     free(icon);
 }
 


### PR DESCRIPTION
Simplifies the Zig API (now only `icon.destroy()` is required). Fixes double free.